### PR TITLE
DirectoryConfigurationStore - sort files before processing

### DIFF
--- a/vertx-configuration-git-store/src/main/java/io/vertx/ext/configuration/git/GitConfigurationStore.java
+++ b/vertx-configuration-git-store/src/main/java/io/vertx/ext/configuration/git/GitConfigurationStore.java
@@ -18,6 +18,7 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
+import java.util.stream.Collectors;
 
 /**
  * @author <a href="http://escoffier.me">Clement Escoffier</a>
@@ -157,8 +158,13 @@ public class GitConfigurationStore implements ConfigurationStore {
           if (call.isSuccessful()) {
             future.complete();
           } else {
-            future.fail("Unable to merge repository - Conflicts: "
-                + call.getMergeResult().getCheckoutConflicts());
+            if (call.getMergeResult() != null) {
+              future.fail("Unable to merge repository - Conflicts: "
+                  + call.getMergeResult().getCheckoutConflicts());
+            } else {
+              future.fail("Unable to rebase repository - Conflicts: "
+                  + call.getRebaseResult().getConflicts());
+            }
           }
         },
         result.completer()
@@ -171,7 +177,7 @@ public class GitConfigurationStore implements ConfigurationStore {
     vertx.executeBlocking(
         fut -> {
           try {
-            fut.complete(FileSet.traverse(path));
+            fut.complete(FileSet.traverse(path).stream().sorted().collect(Collectors.toList()));
           } catch (Throwable e) {
             fut.fail(e);
           }

--- a/vertx-configuration-git-store/src/test/java/io/vertx/ext/configuration/git/GitConfigurationStoreTest.java
+++ b/vertx-configuration-git-store/src/test/java/io/vertx/ext/configuration/git/GitConfigurationStoreTest.java
@@ -516,7 +516,7 @@ public class GitConfigurationStoreTest {
     Async async = tc.async();
     service.getConfiguration(ar -> {
       assertThat(ar.succeeded()).isFalse();
-      assertThat(ar.cause().getMessage()).contains("conflict");
+      assertThat(ar.cause().getMessage()).contains("Conflicts");
       async.complete();
     });
   }
@@ -562,7 +562,7 @@ public class GitConfigurationStoreTest {
     Async async = tc.async();
     service.getConfiguration(ar -> {
       assertThat(ar.succeeded()).isFalse();
-      assertThat(ar.cause().getMessage()).contains("conflict");
+      assertThat(ar.cause().getMessage()).contains("Conflicts");
       async.complete();
     });
   }

--- a/vertx-configuration/src/main/java/io/vertx/ext/configuration/impl/spi/DirectoryConfigurationStore.java
+++ b/vertx-configuration/src/main/java/io/vertx/ext/configuration/impl/spi/DirectoryConfigurationStore.java
@@ -9,6 +9,7 @@ import io.vertx.ext.configuration.utils.FileSet;
 
 import java.io.File;
 import java.util.*;
+import java.util.stream.Collectors;
 
 /**
  * A configuration store loading a set of files from a directory.
@@ -53,7 +54,7 @@ public class DirectoryConfigurationStore implements ConfigurationStore {
     vertx.<List<File>>executeBlocking(
         fut -> {
           try {
-            fut.complete(FileSet.traverse(path));
+            fut.complete(FileSet.traverse(path).stream().sorted().collect(Collectors.toList()));
           } catch (Throwable e) {
             fut.fail(e);
           }


### PR DESCRIPTION
This commit fixes [DirectoryConfigurationStoreTest](https://github.com/cescoffier/vertx-configuration-service/blob/fcefd73769dabea5e2be7f4d2609d1d72418ff38/vertx-configuration/src/test/java/io/vertx/ext/configuration/impl/spi/DirectoryConfigurationStoreTest.java#L190).